### PR TITLE
[rfc] timestamp: rewrite, simplify, fix layering violation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,15 +117,17 @@ mod tests {
         let mut rt1 = vec![];
         let mut rt2 = vec![];
 
-        let ots = DetachedTimestampFile::from_reader(SMALL_TEST);
-        assert!(ots.is_ok());
-        assert!(ots.unwrap().to_writer(&mut rt1).is_ok());
+        let otsr = DetachedTimestampFile::from_reader(SMALL_TEST);
+        assert!(otsr.is_ok());
+        let ots = otsr.unwrap();
+        assert!(ots.to_writer(&mut rt1).is_ok());
         assert_eq!(rt1, SMALL_TEST);
 
-        let ots = DetachedTimestampFile::from_reader(LARGE_TEST);
-        ots.as_ref().unwrap();
-        assert!(ots.is_ok());
-        assert!(ots.unwrap().to_writer(&mut rt2).is_ok());
+        let otsr = DetachedTimestampFile::from_reader(LARGE_TEST);
+        otsr.as_ref().unwrap();
+        assert!(otsr.is_ok());
+        let ots = otsr.unwrap();
+        assert!(ots.to_writer(&mut rt2).is_ok());
         assert_eq!(rt2, LARGE_TEST);
     }
 }


### PR DESCRIPTION
Continues from #6 

This commit rewrites and simplifies the Timestamp interface, fixes some layering
violations, and generally makes it easier to construct/merge timestamps. This is
major breaking change.

Motivation
==========

It's hard to construct timestamps with the current abstraction. This commit
simplifies things:

  * Rename StepData to Step and remove the original Step.

  * Timestamp no longer stores the start_digest which doesn't reflect
    the underlying format. start_digest is now a part of DetachedTimestampFile
    where it should be.

  * A timestamp is just a list of steps, this makes it easy to construct linear
    timestamps.

  * A fork now holds a list of steps. This allows you to easily construct a tree
    of timestamps by pushing a fork to the step list.

  * Remove evaluated data from the expression tree. This behaved like a cache,
    but is superfluous and a potential performance issue when constructing/deserializing large
    timestamp expressions.

Examples
========

Foxglove
--------

In opentimestamps/foxglove, a LinearTimestamp abstraction was needed to work
around the current interface¹. All that code can now be replaced with:

    timestamp.steps.push(Op::Append(vec![0x00]));
    timestamp.steps.push(Op::Prepend(vec![0x00]));

With the added benefit that pushing forks allows you to do non-linear as well. cc @RCasatta 

¹https://github.com/opentimestamps/foxglove/blob/84e32bec3bb4e44d6cd17075e3cdc3056a9d0fd4/src/timestamp.rs

Merging Timestamps
------------------

This is easy as:

     timestamp.steps.extend(other.steps)

Next
====

Before, each step was executed and cached on deserialization. Now that
evaluation tree is free of cached-at-deserialization evaluations, we can create an interpreter that
lazy evaluates the tree.

Here's a quick sketch of a potential evaluator:

```rust
    pub enum ExecResult {
        Done {
            result: Vec<u8>,
            attestation: Option<Attestation>,
        },
        Cont {
            result: Vec<u8>,
            fork: Vec<Step>,
            next: Vec<Step>,
        }
    }

    impl ExecResult {
        pub fn get_result(&self) -> &Vec<u8> {
            match &self {
                ExecResult::Done {result, ..} => result,
                ExecResult::Cont {result, ..} => result,
            }
        }
    }

    /// Executes steps up to a fork or attestation
    fn execute_steps(steps : &[Step], data: &[u8]) -> ExecResult {
        let mut buf : Vec<u8> = data.to_vec();
        for (i, step) in steps.iter().enumerate() {
            match step {
                Step::Op(ref op) => {
                    buf = op.execute(&buf);
                },
                Step::Fork(ref fork) => {
                    return ExecResult::Cont { result: buf, fork: fork.clone(), next: steps[i+1..].to_vec() }
                },
                Step::Attestation(ref att) => {
                    return ExecResult::Done { result: buf, attestation: Some(att.clone()) }
                }
            }
        }

        ExecResult::Done { result: buf, attestation: None }
    }
```

Signed-off-by: William Casarin <jb55@jb55.com>